### PR TITLE
Add image handling for multimodal LLM providers

### DIFF
--- a/dta/dti/coe/context_agent.py
+++ b/dta/dti/coe/context_agent.py
@@ -83,19 +83,30 @@ def _tiff_to_png_bytes(tif_path: str) -> bytes:
         return buf.getvalue()
 
 
-def _image_part(att: Attachment) -> Any:
-    """Convert attachment to image part for multimodal LLM providers.
-
-    Note: Multimodal image analysis is not yet implemented.
-    Context understanding currently relies on text prompts and file metadata.
+def _image_part(att: Attachment) -> str | None:
+    """Convert attachment to base64 PNG thumbnail for multimodal LLM providers.
 
     Args:
         att: File attachment with path to image
 
     Returns:
-        None (image content not currently used in context analysis)
+        Base64-encoded PNG string (512x512 max), or None if conversion fails
     """
-    return None
+    import base64
+
+    from PIL import Image
+
+    if att.path is None or not att.mime_type.startswith("image/"):
+        return None
+    try:
+        png_bytes = _tiff_to_png_bytes(att.path)
+        im = Image.open(io.BytesIO(png_bytes))
+        im.thumbnail((512, 512))
+        buf = io.BytesIO()
+        im.save(buf, format="PNG")
+        return base64.b64encode(buf.getvalue()).decode()
+    except Exception:
+        return None
 
 
 def analyze(req: ChatRequest, registry_types: list[str]) -> ContextUnderstanding:
@@ -117,7 +128,18 @@ def analyze(req: ChatRequest, registry_types: list[str]) -> ContextUnderstanding
     system_msg = f"{SYS}\n\n[REGISTRY_TYPES]={registry_types}"
     user_msg = req.prompt
 
-    messages = [LLMMessage(role="system", content=system_msg), LLMMessage(role="user", content=user_msg)]
+    vision_available = any(p.supports_images for p in router.providers)
+    image_b64_list: list[str] = []
+    if vision_available:
+        for att in req.attachments:
+            b64 = _image_part(att)
+            if b64 is not None:
+                image_b64_list.append(b64)
+
+    messages = [
+        LLMMessage(role="system", content=system_msg),
+        LLMMessage(role="user", content=user_msg, images=image_b64_list or None),
+    ]
 
     # Generate with router (will try Gemini, fallback to Ollama)
     response = router.generate(messages, temperature=0.3)  # Lower temp for structured output

--- a/dta/dti/coe/llm/gemini.py
+++ b/dta/dti/coe/llm/gemini.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import os
 from typing import Any
 
@@ -83,7 +84,10 @@ class GeminiProvider(BaseLLMProvider):
                 # System messages prepended as text
                 contents.insert(0, msg.content)
             elif msg.role == "user":
-                # Note: Image inputs not currently used in pipeline context
+                if msg.images:
+                    for b64_str in msg.images:
+                        raw = base64.b64decode(b64_str)
+                        contents.append(types.Part.from_bytes(data=raw, mime_type="image/png"))
                 contents.append(msg.content)
             elif msg.role == "assistant":
                 # Gemini doesn't use assistant messages in the same way

--- a/dta/dti/coe/llm/ollama.py
+++ b/dta/dti/coe/llm/ollama.py
@@ -78,7 +78,10 @@ class OllamaProvider(BaseLLMProvider):
         # Convert messages to Ollama format
         ollama_messages = []
         for msg in messages:
-            ollama_messages.append({"role": msg.role, "content": msg.content})
+            msg_dict: dict[str, Any] = {"role": msg.role, "content": msg.content}
+            if msg.images:
+                msg_dict["images"] = msg.images
+            ollama_messages.append(msg_dict)
 
         payload = {
             "model": self.model,


### PR DESCRIPTION
## Description

Implements multimodal image support in the context analysis pipeline so the LLM sees uploaded satellite imagery when classifying user intent, not just the text prompt. Previously `_image_part()` was a stub returning `None` and provider `generate()` methods ignored `LLMMessage.images` entirely.

## Related Issue

Fixes [#21](https://github.com/IPT-MMDA/DT4LC-project/issues/21)

## Type of Change

<!-- Mark with an `x` all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes

## Changes Made

- Implemented `_image_part()` in `context_agent.py`: converts a GeoTIFF attachment to a base64 PNG thumbnail (512×512 max) using the existing `_tiff_to_png_bytes()` helper; returns `None` on missing path, wrong MIME type, or any conversion error
- Updated `analyze()` in `context_agent.py`: checks `supports_images` across router providers before doing any conversion work; attaches image thumbnails to the user `LLMMessage` only when a vision-capable provider is available
- Updated `GeminiProvider.generate()` in `llm/gemini.py`: decodes base64 image strings from `LLMMessage.images` into `types.Part.from_bytes()` objects and prepends them to the Gemini content list
- Updated `OllamaProvider.generate()` in `llm/ollama.py`: passes `LLMMessage.images` (already base64 `list[str]`) directly in the Ollama chat API message dict for vision models (llava, bakllava)

## Additional Notes

Non-vision providers (Groq, Apertus) are unaffected — their `supports_images` returns `False`, so `analyze()` skips image conversion entirely and those providers receive text-only messages as before.