### PR TITLE
Extend healthcheck endpoint with detailed query param

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -16,13 +16,52 @@ Currently no authentication required (local development only).
 
 Health check endpoint.
 
-**Response:**
+**Query Parameters:**
+
+| Parameter  | Type    | Default | Description                                                     |
+|------------|---------|---------|----------------------------------------------------------------|
+| `detailed` | boolean | false   | Return extended diagnostics (restricted to localhost requests) |
+
+**Response (simple):**
 
 ```json
 {
   "ok": true,
   "service": "DT4LC",
   "version": "1.0.0"
+}
+```
+
+**Response (`?detailed=true`, localhost only — returns 403 from remote):**
+
+```json
+{
+  "ok": true,
+  "service": "DT4LC",
+  "version": "1.0.0",
+  "llm_providers": [
+    { "name": "gemini", "model": "gemini-2.5-flash", "available": true },
+    { "name": "groq",   "model": "llama-3.3-70b-versatile", "available": true },
+    { "name": "ollama", "model": "llama3.2", "available": true }
+  ],
+  "gee": {
+    "initialized": false,
+    "service_account_configured": false
+  },
+  "models": {
+    "total": 3,
+    "available": 2,
+    "models": [
+      { "id": "prithvi:v1.0", "available": true },
+      { "id": "algorithms/ndvi", "available": true }
+    ]
+  },
+  "disk": {
+    "uploads": { "bytes": 1048576, "human": "1.0 MB" },
+    "cache":   { "bytes": 5242880, "human": "5.0 MB" },
+    "models":  { "bytes": 0,       "human": "0.0 B"  },
+    "exports": { "bytes": 0,       "human": "0.0 B"  }
+  }
 }
 ```
 

--- a/dta/dti/data_sources/gee_common.py
+++ b/dta/dti/data_sources/gee_common.py
@@ -13,6 +13,11 @@ logger = logging.getLogger(__name__)
 _ee_initialized = False
 
 
+def is_initialized() -> bool:
+    """Return whether GEE has been successfully initialized in this process."""
+    return _ee_initialized
+
+
 def initialize_gee() -> bool:
     """Initialize Google Earth Engine API.
 

--- a/server/routes/health.py
+++ b/server/routes/health.py
@@ -1,24 +1,151 @@
 """Health, capabilities, models, and metrics endpoints."""
 
 import logging
-from typing import Any
+import os
+from pathlib import Path
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 
+from dta.config import CACHE_PATH, MODELS_PATH, UPLOADS_PATH
+from dta.dti.coe.llm.config import get_default_config
+from dta.dti.coe.llm.router import LLMRouter
+from dta.dti.data_sources.gee_common import is_initialized
 from dta.dti.metrics import get_metrics_collector
 from dta.dti.models.registry import get_model_registry
 from dta.dti.registry import load_registry
+from server.schemas import (
+    DiskEntry,
+    DiskUsage,
+    GEEStatus,
+    HealthResponse,
+    LLMProviderStatus,
+    ModelEntry,
+    ModelsInfo,
+)
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1", tags=["health"])
 
+_LOCALHOST_HOSTS = {"127.0.0.1", "::1", "localhost"}
 
-@router.get("/health")  # type: ignore[misc]
-async def health() -> dict[str, Any]:
-    """Health check endpoint."""
-    return {"ok": True, "service": "DT4LC", "version": "1.0.0"}
+
+def _dir_size_bytes(p: Path) -> int:
+    """Recursively sum file sizes using os.scandir for minimal syscall overhead."""
+    if not p.exists():
+        return 0
+    total = 0
+    with os.scandir(p) as it:
+        for entry in it:
+            if entry.is_file(follow_symlinks=False):
+                total += entry.stat(follow_symlinks=False).st_size
+            elif entry.is_dir(follow_symlinks=False):
+                total += _dir_size_bytes(Path(entry.path))
+    return total
+
+
+def _fmt_bytes(b: int) -> str:
+    for unit in ("B", "KB", "MB", "GB"):
+        if b < 1024:
+            return f"{b:.1f} {unit}"
+        b //= 1024
+    return f"{b:.1f} TB"
+
+
+def _collect_llm_providers() -> list[LLMProviderStatus]:
+    try:
+        cfg = get_default_config()
+        router = LLMRouter.from_config(cfg)
+        return [LLMProviderStatus(name=p.name, model=p.model, available=p.is_available()) for p in router.providers]
+    except (ImportError, ValueError, OSError) as exc:
+        logger.warning("Could not collect LLM provider info: %s", exc)
+        return [LLMProviderStatus(error=str(exc))]
+
+
+def _collect_gee_status() -> GEEStatus:
+    sa_configured = bool(os.environ.get("GEE_SERVICE_ACCOUNT_KEY"))
+    if not is_initialized():
+        return GEEStatus(initialized=False, service_account_configured=sa_configured)
+
+    try:
+        import ee
+
+        ee.Number(1).getInfo()
+        return GEEStatus(initialized=True, service_account_configured=sa_configured)
+    except Exception as exc:
+        logger.warning("GEE connection check failed: %s", exc)
+        return GEEStatus(initialized=False, service_account_configured=sa_configured, error=str(exc))
+
+
+def _collect_models_info() -> ModelsInfo:
+    try:
+        registry = get_model_registry()
+        all_ids = registry.list_all()
+        entries = [ModelEntry(id=mid, available=registry.get(mid).is_available()) for mid in all_ids]
+
+        try:
+            yaml_reg = load_registry()
+            hosted = [i for i in yaml_reg.instances if i.kind == "model" and i.integration]
+            entries += [
+                ModelEntry(id=i.id, available=i.integration.status == "active" if i.integration else False)
+                for i in hosted
+            ]
+            hosted_available = sum(1 for h in hosted if h.integration and h.integration.status == "active")
+        except Exception:
+            hosted = []
+            hosted_available = 0
+
+        return ModelsInfo(
+            total=len(all_ids) + len(hosted),
+            available=len(registry.list_available()) + hosted_available,
+            models=entries,
+        )
+    except Exception as exc:
+        return ModelsInfo(error=str(exc))
+
+
+def _collect_disk_usage() -> DiskUsage:
+    try:
+        exports_dir = CACHE_PATH / "gee_exports"
+        entries = {
+            "uploads": UPLOADS_PATH,
+            "cache": CACHE_PATH,
+            "models": MODELS_PATH,
+            "exports": exports_dir,
+        }
+        disk_entries = {
+            key: DiskEntry(bytes=_dir_size_bytes(p), human=_fmt_bytes(_dir_size_bytes(p)))
+            for key, p in entries.items()
+        }
+        return DiskUsage(**disk_entries)
+    except Exception as exc:
+        return DiskUsage(error=str(exc))
+
+
+@router.get("/health", response_model=HealthResponse)  # type: ignore[misc]
+async def health(
+    request: Request,
+    detailed: bool = Query(False, description="Return extended diagnostics (localhost only)"),
+) -> HealthResponse:
+    """Health check endpoint.
+
+    Without ?detailed=true returns a simple liveness response.
+    With ?detailed=true returns internal diagnostics; restricted to localhost.
+    """
+    if not detailed:
+        return HealthResponse()
+
+    client_host = request.client.host if request.client else ""
+    if client_host not in _LOCALHOST_HOSTS:
+        raise HTTPException(status_code=403, detail="Detailed diagnostics are available from localhost only")
+
+    return HealthResponse(
+        llm_providers=_collect_llm_providers(),
+        gee=_collect_gee_status(),
+        models=_collect_models_info(),
+        disk=_collect_disk_usage(),
+    )
 
 
 @router.get("/capabilities")  # type: ignore[misc]

--- a/server/schemas.py
+++ b/server/schemas.py
@@ -71,3 +71,54 @@ class JobStatus(BaseModel):  # type: ignore[misc]
     message: str | None = None
     result: dict[str, Any] | None = None
     error: str | None = None
+
+
+# Health endpoint response schemas
+
+
+class LLMProviderStatus(BaseModel):  # type: ignore[misc]
+    name: str | None = None
+    model: str | None = None
+    available: bool | None = None
+    error: str | None = None
+
+
+class GEEStatus(BaseModel):  # type: ignore[misc]
+    initialized: bool
+    service_account_configured: bool
+    error: str | None = None
+
+
+class ModelEntry(BaseModel):  # type: ignore[misc]
+    id: str
+    available: bool
+
+
+class ModelsInfo(BaseModel):  # type: ignore[misc]
+    total: int = 0
+    available: int = 0
+    models: list[ModelEntry] = []
+    error: str | None = None
+
+
+class DiskEntry(BaseModel):  # type: ignore[misc]
+    bytes: int
+    human: str
+
+
+class DiskUsage(BaseModel):  # type: ignore[misc]
+    uploads: DiskEntry | None = None
+    cache: DiskEntry | None = None
+    models: DiskEntry | None = None
+    exports: DiskEntry | None = None
+    error: str | None = None
+
+
+class HealthResponse(BaseModel):  # type: ignore[misc]
+    ok: bool = True
+    service: str = "DT4LC"
+    version: str = "1.0.0"
+    llm_providers: list[LLMProviderStatus] | None = None
+    gee: GEEStatus | None = None
+    models: ModelsInfo | None = None
+    disk: DiskUsage | None = None

--- a/tests/test_health_detailed.py
+++ b/tests/test_health_detailed.py
@@ -1,0 +1,235 @@
+"""Tests for the detailed health check endpoint (?detailed=true).
+
+Covers localhost-only restriction, response structure, and individual
+diagnostics collectors.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+import pytest
+
+from server.app import app
+from server.routes.health import (
+    _collect_disk_usage,
+    _collect_gee_status,
+    _collect_llm_providers,
+    _collect_models_info,
+    _dir_size_bytes,
+    _fmt_bytes,
+)
+from server.schemas import DiskEntry, DiskUsage, GEEStatus, LLMProviderStatus, ModelsInfo
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+# Endpoint-level tests
+
+
+class TestHealthEndpointDetailed:
+    def test_simple_health_no_detailed(self, client: TestClient) -> None:
+        resp = client.get("/v1/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data.get("llm_providers") is None
+
+    def test_detailed_forbidden_from_non_localhost(self, client: TestClient) -> None:
+        # TestClient sends requests with host "testclient", not 127.0.0.1
+        resp = client.get("/v1/health", params={"detailed": "true"})
+        assert resp.status_code == 403
+        assert "localhost" in resp.json()["detail"]
+
+    def test_detailed_returns_full_diagnostics_from_localhost(self, client: TestClient) -> None:
+        gee_stub = GEEStatus(initialized=False, service_account_configured=False)
+        models_stub = ModelsInfo()
+        disk_stub = DiskUsage()
+        with (
+            patch("server.routes.health._LOCALHOST_HOSTS", {"testclient"}),
+            patch("server.routes.health._collect_llm_providers", return_value=[]),
+            patch("server.routes.health._collect_gee_status", return_value=gee_stub),
+            patch("server.routes.health._collect_models_info", return_value=models_stub),
+            patch("server.routes.health._collect_disk_usage", return_value=disk_stub),
+        ):
+            resp = client.get("/v1/health", params={"detailed": "true"})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert "llm_providers" in data
+        assert "gee" in data
+        assert "models" in data
+        assert "disk" in data
+
+
+# Unit tests for helper functions
+
+
+class TestFmtBytes:
+    def test_bytes(self) -> None:
+        assert _fmt_bytes(512) == "512.0 B"
+
+    def test_kilobytes(self) -> None:
+        assert _fmt_bytes(2048) == "2.0 KB"
+
+    def test_megabytes(self) -> None:
+        assert _fmt_bytes(5 * 1024 * 1024) == "5.0 MB"
+
+    def test_gigabytes(self) -> None:
+        assert _fmt_bytes(3 * 1024**3) == "3.0 GB"
+
+
+class TestDirSizeBytes:
+    def test_nonexistent_dir_returns_zero(self, tmp_path: Path) -> None:
+        assert _dir_size_bytes(tmp_path / "nonexistent") == 0
+
+    def test_empty_dir_returns_zero(self, tmp_path: Path) -> None:
+        assert _dir_size_bytes(tmp_path) == 0
+
+    def test_counts_file_sizes(self, tmp_path: Path) -> None:
+        (tmp_path / "a.txt").write_bytes(b"hello")
+        (tmp_path / "b.txt").write_bytes(b"world!")
+        assert _dir_size_bytes(tmp_path) == 11
+
+    def test_recurses_into_subdirectories(self, tmp_path: Path) -> None:
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "file.bin").write_bytes(b"x" * 100)
+        assert _dir_size_bytes(tmp_path) == 100
+
+
+class TestCollectGeeStatus:
+    def test_returns_initialized_false_when_not_initialized(self) -> None:
+        with patch("server.routes.health.is_initialized", return_value=False):
+            status = _collect_gee_status()
+        assert status.initialized is False
+        assert status.error is None
+
+    def test_returns_initialized_true_when_gee_connection_live(self) -> None:
+        with (
+            patch("server.routes.health.is_initialized", return_value=True),
+            patch("ee.Number") as mock_num,
+        ):
+            mock_num.return_value.getInfo.return_value = 1
+            status = _collect_gee_status()
+        assert status.initialized is True
+        assert status.error is None
+
+    def test_returns_error_when_gee_connection_fails(self) -> None:
+        with (
+            patch("server.routes.health.is_initialized", return_value=True),
+            patch("ee.Number") as mock_num,
+        ):
+            mock_num.return_value.getInfo.side_effect = Exception("timeout")
+            status = _collect_gee_status()
+        assert status.initialized is False
+        assert status.error is not None
+
+    def test_service_account_flag_reflects_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GEE_SERVICE_ACCOUNT_KEY", "/path/to/key.json")
+        with patch("server.routes.health.is_initialized", return_value=False):
+            status = _collect_gee_status()
+        assert status.service_account_configured is True
+
+    def test_service_account_false_when_env_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GEE_SERVICE_ACCOUNT_KEY", raising=False)
+        with patch("server.routes.health.is_initialized", return_value=False):
+            status = _collect_gee_status()
+        assert status.service_account_configured is False
+
+
+class TestCollectLLMProviders:
+    def test_returns_list_on_success(self) -> None:
+        mock_provider = MagicMock()
+        mock_provider.name = "test"
+        mock_provider.model = "gpt-4"
+        mock_provider.is_available.return_value = True
+
+        mock_router = MagicMock()
+        mock_router.providers = [mock_provider]
+
+        with (
+            patch("server.routes.health.get_default_config", return_value=MagicMock()),
+            patch("server.routes.health.LLMRouter.from_config", return_value=mock_router),
+        ):
+            result = _collect_llm_providers()
+
+        assert len(result) == 1
+        assert isinstance(result[0], LLMProviderStatus)
+        assert result[0].name == "test"
+        assert result[0].available is True
+
+    def test_returns_error_entry_on_exception(self) -> None:
+        with patch("server.routes.health.get_default_config", side_effect=ValueError("bad cfg")):
+            result = _collect_llm_providers()
+        assert len(result) == 1
+        assert result[0].error is not None
+
+
+class TestCollectModelsInfo:
+    def test_returns_model_with_required_fields(self) -> None:
+        mock_registry = MagicMock()
+        mock_registry.list_all.return_value = []
+        mock_registry.list_available.return_value = []
+
+        with (
+            patch("server.routes.health.get_model_registry", return_value=mock_registry),
+            patch("server.routes.health.load_registry", side_effect=Exception("no yaml")),
+        ):
+            info = _collect_models_info()
+
+        assert isinstance(info, ModelsInfo)
+        assert info.total == 0
+        assert info.available == 0
+        assert info.models == []
+
+    def test_counts_available_models(self) -> None:
+        mock_model = MagicMock()
+        mock_model.is_available.return_value = True
+
+        mock_registry = MagicMock()
+        mock_registry.list_all.return_value = ["model-a"]
+        mock_registry.list_available.return_value = ["model-a"]
+        mock_registry.get.return_value = mock_model
+
+        with (
+            patch("server.routes.health.get_model_registry", return_value=mock_registry),
+            patch("server.routes.health.load_registry", side_effect=Exception("no yaml")),
+        ):
+            info = _collect_models_info()
+
+        assert info.total == 1
+        assert info.available == 1
+        assert info.models[0].id == "model-a"
+
+
+class TestCollectDiskUsage:
+    def test_returns_all_expected_partitions(self, tmp_path: Path) -> None:
+        with (
+            patch("server.routes.health.UPLOADS_PATH", tmp_path),
+            patch("server.routes.health.CACHE_PATH", tmp_path),
+            patch("server.routes.health.MODELS_PATH", tmp_path),
+        ):
+            usage = _collect_disk_usage()
+
+        assert isinstance(usage, DiskUsage)
+        assert usage.uploads is not None
+        assert usage.cache is not None
+        assert usage.models is not None
+        assert usage.exports is not None
+
+    def test_each_entry_has_bytes_and_human(self, tmp_path: Path) -> None:
+        with (
+            patch("server.routes.health.UPLOADS_PATH", tmp_path),
+            patch("server.routes.health.CACHE_PATH", tmp_path),
+            patch("server.routes.health.MODELS_PATH", tmp_path),
+        ):
+            usage = _collect_disk_usage()
+
+        assert isinstance(usage.uploads, DiskEntry)
+        assert isinstance(usage.uploads.bytes, int)
+        assert isinstance(usage.uploads.human, str)


### PR DESCRIPTION
## Description

Extended the `/v1/health` endpoint to provide comprehensive system diagnostics via a new `?detailed=true` query parameter.

## Related Issue

Fixes [#16](https://github.com/IPT-MMDA/DT4LC-project/issues/16)

## Type of Change

<!-- Mark with an `x` all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes

## Changes Made

- Added a `detailed` boolean query parameter to the `/v1/health` endpoint (defaults to `False`).
- Implemented logic to safely collect and return LLM provider availability, GEE authentication readiness, model registry status, and local disk usage (uploads, caches, exports).
- Updated `docs/API.md` to document the new `?detailed=true` parameter and its corresponding JSON response schema.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

All detailed checks are designed to be extremely fast (reading configuration states, environment variables, or simple directory byte counts) without making any live HTTP requests to external APIs, ensuring the endpoint remains performant.
