### PR TITLE
Update CI branches to include 'dev' instead of 'develop'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master, main, develop]
+    branches: [master, main, dev]
   pull_request:
-    branches: [master, main, develop]
+    branches: [master, main, dev]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Description

Fix CI to cover `dev` branch over `develop` which was included by mistake

## Related Issue

x

## Type of Change

<!-- Mark with an `x` all that apply -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes

## Changes Made

<!-- List the main changes -->

- ci file

## Testing

<!-- Describe the tests you ran -->

- [ ] I have run `task test` and all tests pass
- [ ] I have run `task lint` and fixed any issues
- [ ] I have run `task typecheck` and fixed any type errors
- [ ] I have added tests that prove my fix/feature works

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

x

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Add any additional context or notes for reviewers -->
