### PR TITLE
#15 File picker implementation

### DIFF
--- a/cognitive_ui/src/components/chat/FileUploadDropzone.tsx
+++ b/cognitive_ui/src/components/chat/FileUploadDropzone.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback } from 'react';
 import { Upload, X, Loader2, AlertCircle, CheckCircle, Paperclip, Download, Database } from 'lucide-react';
+import type { GeoTIFFFile } from '../../api/hooks/useUpload';
 import { useUploadFile, useListFiles } from '../../api/hooks/useUpload';
 import { useAppStore } from '../../store/useAppStore';
 import { uploadLogger as logger } from '../../utils/logger';
@@ -23,8 +24,36 @@ export function FileUploadDropzone({ onClose, compact = false }: FileUploadDropz
   const [showAvailableFiles, setShowAvailableFiles] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const uploadFile = useUploadFile();
-  const { data: availableFiles } = useListFiles();
+  const { data: availableFiles, isLoading: isLoadingFiles, isError: isFilesError } = useListFiles();
   const { addAttachment, uploadedAttachments } = useAppStore();
+
+  const formatFileSize = (bytes: number) => {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  };
+
+  const formatDate = (timestamp: number) => {
+    return new Date(timestamp * 1000).toLocaleDateString();
+  };
+
+  const isAttached = (file: GeoTIFFFile) => {
+    return uploadedAttachments.some(att => att.id === file.id);
+  };
+
+  const attachAvailableFile = (file: GeoTIFFFile) => {
+    if (isAttached(file)) return;
+
+    addAttachment({
+      id: file.id,
+      filename: file.filename,
+      path: file.path,
+      mime_type: 'image/tiff',
+      size_bytes: file.size_bytes,
+    });
+
+    if (onClose) onClose();
+  };
 
   const handleDrag = useCallback((e: React.DragEvent) => {
     e.preventDefault();
@@ -115,78 +144,157 @@ export function FileUploadDropzone({ onClose, compact = false }: FileUploadDropz
     fileInputRef.current?.click();
   };
 
+  const renderAvailableFiles = () => (
+    <div className="space-y-2">
+      {isLoadingFiles ? (
+        <div className="flex items-center justify-center py-6">
+          <Loader2 className="w-5 h-5 text-primary-500 animate-spin" />
+        </div>
+      ) : isFilesError ? (
+        <div className="flex items-center gap-2 py-3 text-sm text-red-600 dark:text-red-400">
+          <AlertCircle className="w-4 h-4" />
+          Failed to load files
+        </div>
+      ) : availableFiles && availableFiles.length > 0 ? (
+        <>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+            Select a file to add to chat:
+          </p>
+          {availableFiles.map((file) => (
+            <button
+              key={file.id}
+              type="button"
+              onClick={() => attachAvailableFile(file)}
+              disabled={isAttached(file)}
+              className="w-full text-left px-3 py-2 bg-gray-50 dark:bg-gray-950 hover:bg-gray-100 dark:hover:bg-gray-900 disabled:opacity-60 rounded border border-gray-200 dark:border-gray-800 transition-colors"
+            >
+              <div className="flex items-start gap-2">
+                {file.source === 'export' ? (
+                  <Download className="w-4 h-4 text-blue-500 flex-shrink-0 mt-0.5" />
+                ) : (
+                  <Upload className="w-4 h-4 text-green-500 flex-shrink-0 mt-0.5" />
+                )}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                      {file.filename}
+                    </p>
+                    {isAttached(file) && (
+                      <CheckCircle className="w-3 h-3 text-green-500 flex-shrink-0" />
+                    )}
+                  </div>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    {file.source} | {formatFileSize(file.size_bytes)} | {formatDate(file.modified)}
+                  </p>
+                </div>
+              </div>
+            </button>
+          ))}
+        </>
+      ) : (
+        <div className="text-center py-6 text-gray-400">
+          <Database className="w-8 h-8 mx-auto mb-2 opacity-50" />
+          <p className="text-xs">No files available</p>
+        </div>
+      )}
+    </div>
+  );
+
   // Compact inline version
   if (compact) {
     return (
-      <div
-        className={`rounded-lg border-2 border-dashed p-4 transition-colors ${
-          dragActive
-            ? 'border-primary-500 bg-primary-50 dark:bg-primary-950'
-            : uploadFile.isError
-            ? 'border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-950'
-            : 'border-gray-300 dark:border-gray-700 bg-gray-50 dark:bg-gray-900'
-        }`}
-        onDragEnter={handleDrag}
-        onDragLeave={handleDrag}
-        onDragOver={handleDrag}
-        onDrop={handleDrop}
-      >
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept=".tif,.tiff,.geotiff"
-          onChange={handleChange}
-          className="hidden"
-        />
+      <div className="space-y-2">
+        <div className="flex gap-2">
+          <div
+            className={`flex-1 rounded-lg border-2 border-dashed p-4 transition-colors ${
+              dragActive
+                ? 'border-primary-500 bg-primary-50 dark:bg-primary-950'
+                : uploadFile.isError
+                ? 'border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-950'
+                : 'border-gray-300 dark:border-gray-700 bg-gray-50 dark:bg-gray-900'
+            }`}
+            onDragEnter={handleDrag}
+            onDragLeave={handleDrag}
+            onDragOver={handleDrag}
+            onDrop={handleDrop}
+          >
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".tif,.tiff,.geotiff"
+              onChange={handleChange}
+              className="hidden"
+            />
 
-        {uploadFile.isPending ? (
-          <div className="flex items-center gap-3">
-            <Loader2 className="w-5 h-5 text-primary-500 animate-spin" />
-            <span className="text-sm text-gray-600 dark:text-gray-400">Uploading...</span>
-          </div>
-        ) : uploadFile.isError ? (
-          <div className="flex items-center gap-3">
-            <AlertCircle className="w-5 h-5 text-red-500" />
-            <span className="text-sm text-red-600 dark:text-red-400">
-              {uploadFile.error instanceof Error ? uploadFile.error.message : 'Upload failed'}
-            </span>
-            <button
-              onClick={() => uploadFile.reset()}
-              className="ml-auto text-xs text-primary-500 hover:text-primary-600"
-            >
-              Try again
-            </button>
-          </div>
-        ) : recentUpload ? (
-          <div className="flex items-center gap-3">
-            <CheckCircle className="w-5 h-5 text-green-500" />
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
-                {recentUpload.filename}
-              </p>
-              <p className="text-xs text-gray-500">
-                {recentUpload.size[0]} x {recentUpload.size[1]} px
-              </p>
-            </div>
-            {recentUpload.preview_png_base64 && (
-              <img
-                src={`data:image/png;base64,${recentUpload.preview_png_base64}`}
-                alt="Preview"
-                className="w-12 h-12 rounded object-cover"
-              />
+            {uploadFile.isPending ? (
+              <div className="flex items-center gap-3">
+                <Loader2 className="w-5 h-5 text-primary-500 animate-spin" />
+                <span className="text-sm text-gray-600 dark:text-gray-400">Uploading...</span>
+              </div>
+            ) : uploadFile.isError ? (
+              <div className="flex items-center gap-3">
+                <AlertCircle className="w-5 h-5 text-red-500" />
+                <span className="text-sm text-red-600 dark:text-red-400">
+                  {uploadFile.error instanceof Error ? uploadFile.error.message : 'Upload failed'}
+                </span>
+                <button
+                  onClick={() => uploadFile.reset()}
+                  className="ml-auto text-xs text-primary-500 hover:text-primary-600"
+                >
+                  Try again
+                </button>
+              </div>
+            ) : recentUpload ? (
+              <div className="flex items-center gap-3">
+                <CheckCircle className="w-5 h-5 text-green-500" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                    {recentUpload.filename}
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    {recentUpload.size[0]} x {recentUpload.size[1]} px
+                  </p>
+                </div>
+                {recentUpload.preview_png_base64 && (
+                  <img
+                    src={`data:image/png;base64,${recentUpload.preview_png_base64}`}
+                    alt="Preview"
+                    className="w-12 h-12 rounded object-cover"
+                  />
+                )}
+              </div>
+            ) : (
+              <div
+                className="flex items-center gap-3 cursor-pointer"
+                onClick={onButtonClick}
+              >
+                <Upload className="w-5 h-5 text-gray-400" />
+                <div className="flex-1">
+                  <p className="text-sm text-gray-700 dark:text-gray-300">
+                    Drop a GeoTIFF here or <span className="text-primary-500">browse</span>
+                  </p>
+                </div>
+              </div>
             )}
           </div>
-        ) : (
-          <div
-            className="flex items-center gap-3 cursor-pointer"
-            onClick={onButtonClick}
+
+          <button
+            type="button"
+            onClick={() => setShowAvailableFiles(!showAvailableFiles)}
+            className={`px-4 rounded-lg transition-colors flex items-center gap-2 ${
+              showAvailableFiles
+                ? 'bg-primary-100 dark:bg-primary-900 text-primary-600 dark:text-primary-400'
+                : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
+            }`}
+            title="Choose an existing file"
           >
-            <Upload className="w-5 h-5 text-gray-400" />
-            <div className="flex-1">
-              <p className="text-sm text-gray-700 dark:text-gray-300">
-                Drop a GeoTIFF here or <span className="text-primary-500">browse</span>
-              </p>
-            </div>
+            <Database className="w-5 h-5" />
+          </button>
+        </div>
+
+        {showAvailableFiles && (
+          <div className="bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-800 shadow-lg p-3 max-h-64 overflow-y-auto">
+            {renderAvailableFiles()}
           </div>
         )}
       </div>
@@ -237,53 +345,7 @@ export function FileUploadDropzone({ onClose, compact = false }: FileUploadDropz
       )}
 
       {/* Available files list */}
-      {showAvailableFiles && (
-        <div className="space-y-2">
-          {availableFiles && availableFiles.length > 0 ? (
-            <>
-              <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
-                Select a file to add to chat:
-              </p>
-              {availableFiles.map((file) => (
-                <button
-                  key={file.id}
-                  onClick={() => {
-                    addAttachment({
-                      id: file.id,
-                      filename: file.filename,
-                      path: file.path,
-                      mime_type: 'image/tiff',
-                    });
-                    if (onClose) onClose();
-                  }}
-                  className="w-full text-left px-3 py-2 bg-gray-50 dark:bg-gray-950 hover:bg-gray-100 dark:hover:bg-gray-900 rounded border border-gray-200 dark:border-gray-800 transition-colors"
-                >
-                  <div className="flex items-start gap-2">
-                    {file.source === 'export' ? (
-                      <Download className="w-4 h-4 text-blue-500 flex-shrink-0 mt-0.5" />
-                    ) : (
-                      <Upload className="w-4 h-4 text-green-500 flex-shrink-0 mt-0.5" />
-                    )}
-                    <div className="flex-1 min-w-0">
-                      <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
-                        {file.filename}
-                      </p>
-                      <p className="text-xs text-gray-500 dark:text-gray-400">
-                        {file.size[0]} × {file.size[1]} px • {(file.size_bytes / (1024 * 1024)).toFixed(1)} MB
-                      </p>
-                    </div>
-                  </div>
-                </button>
-              ))}
-            </>
-          ) : (
-            <div className="text-center py-6 text-gray-400">
-              <Database className="w-8 h-8 mx-auto mb-2 opacity-50" />
-              <p className="text-xs">No files available</p>
-            </div>
-          )}
-        </div>
-      )}
+      {showAvailableFiles && renderAvailableFiles()}
 
       {/* Upload zone - only show when not browsing */}
       {!showAvailableFiles && (


### PR DESCRIPTION
## Description

Adds a file picker to the Chat upload dropzone so users can attach GeoTIFFs that already exist on the server instead of re-uploading them.

The picker uses the existing `/v1/files` data through `useListFiles()` and shows each file's filename, source, size, and modified date. Selecting a file adds it to the current chat attachments using the existing attachment store flow.

## Related Issue

Closes #15 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes

## Changes Made

- Added an existing-file picker button next to the compact Chat upload dropzone
- Listed server-side GeoTIFFs from `/v1/files` with filename, source, size, and modified date
- Wired file selection into the existing `addAttachment()` flow for the current chat message

## Testing

- [ ] I have run `task test` and all tests pass
- [ ] I have run `task lint` and fixed any issues
- [ ] I have run `task typecheck` and fixed any type errors
- [ ] I have added tests that prove my fix/feature works

Manual testing:
- Opened Chat upload UI
- Verified the new picker button appears next to the upload dropzone
- Verified server-side files appear in the picker
- Verified selecting a listed GeoTIFF attaches it to the current chat message

## Screenshots (if applicable)

<img width="1582" height="155" alt="image" src="https://github.com/user-attachments/assets/f488a986-217c-4c28-982b-761f97a66dad" />

<img width="1560" height="392" alt="image" src="https://github.com/user-attachments/assets/4e0da9ca-cc37-41b0-8572-dda97ee29a39" />

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

Known existing behavior observed during manual testing:
- Uploaded files are saved on the backend with an 8-character prefix to avoid filename collisions. Because `/v1/files` returns saved filenames, the picker displays those prefixed names.
- The `/v1/files` query can remain cached briefly after upload, so newly uploaded files may not appear immediately in the picker in some flows. A follow-up could invalidate or refetch the `files` query after successful upload.